### PR TITLE
Bugfix: Correct element index for large images

### DIFF
--- a/bin/cat.go
+++ b/bin/cat.go
@@ -13,6 +13,10 @@ var (
 	cat_command_file = cat_command.Arg(
 		"file", "The image file to inspect",
 	).Required().OpenFile(os.O_RDONLY, os.FileMode(0666))
+
+	cat_command_start = cat_command.Flag(
+		"start", "The start offset",
+	).Uint64()
 )
 
 func doCat() {
@@ -24,7 +28,7 @@ func doCat() {
 	kingpin.FatalIfError(err, "Can not open file")
 
 	buff := make([]byte, 1024*1024*10)
-	offset := uint64(0)
+	offset := uint64(*cat_command_start)
 	for offset < file_obj.Metadata.VirtualDiskSize {
 		to_read := uint64(len(buff))
 		if offset+to_read > file_obj.Metadata.VirtualDiskSize {
@@ -38,6 +42,7 @@ func doCat() {
 		offset += uint64(n)
 	}
 }
+
 func init() {
 	command_handlers = append(command_handlers, func(command string) bool {
 		switch command {

--- a/bin/cmp.go
+++ b/bin/cmp.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/Velocidex/go-vhdx/parser"
+	"github.com/alecthomas/kingpin/v2"
+	ntfs_parser "www.velocidex.com/golang/go-ntfs/parser"
+)
+
+var (
+	cmp_command      = app.Command("cmp", "Compare a VHDX file")
+	cmp_command_file = cmp_command.Arg(
+		"file", "The VHDX image file to inspect",
+	).Required().OpenFile(os.O_RDONLY, os.FileMode(0666))
+
+	cmp_command_file_original = cmp_command.Arg(
+		"target", "The raw image file to compare with",
+	).Required().OpenFile(os.O_RDONLY, os.FileMode(0666))
+
+	cmp_command_size = cmp_command.Arg(
+		"size", "The size of image to compare",
+	).Required().Uint64()
+
+	cmp_command_start = cmp_command.Flag(
+		"start", "The start offset of image to compare",
+	).Uint64()
+
+	cmp_command_buffer_size = cmp_command.Flag(
+		"buffers", "The size of the buffers to compare",
+	).Default("10485760").Uint64()
+)
+
+func doCmp() {
+	reader, err := ntfs_parser.NewPagedReader(&ntfs_parser.OffsetReader{
+		Reader: *cmp_command_file,
+	}, 1024, 10000)
+	kingpin.FatalIfError(err, "Can not open file")
+
+	file_obj, err := parser.NewVHDXFile(reader)
+	kingpin.FatalIfError(err, "Can not open file")
+
+	buff := make([]byte, *cmp_command_buffer_size)
+	buff2 := make([]byte, *cmp_command_buffer_size)
+
+	offset := uint64(*cmp_command_start)
+	for offset < *cmp_command_size {
+		fmt.Printf("Checking offset %v\n", offset)
+
+		to_read := uint64(len(buff))
+		if offset+to_read > *cmp_command_size {
+			to_read = *cmp_command_size - offset
+		}
+
+		n, err := file_obj.ReadAt(buff, int64(offset))
+		kingpin.FatalIfError(err, "Can not read file")
+
+		n2, err := (*cmp_command_file_original).ReadAt(buff2, int64(offset))
+		kingpin.FatalIfError(err, "Can not read file")
+
+		if n != n2 {
+			fmt.Printf("Offset %v: Unequal buffer reads %v vs %v\n",
+				offset, n, n2)
+			break
+		}
+
+		if bytes.Compare(buff[:n], buff2[:n]) != 0 {
+			fmt.Printf("Offset %v: Error Reading Buffers\n", offset)
+			break
+		}
+
+		offset += uint64(n)
+	}
+}
+
+func init() {
+	command_handlers = append(command_handlers, func(command string) bool {
+		switch command {
+		case cmp_command.FullCommand():
+			doCmp()
+		default:
+			return false
+		}
+		return true
+	})
+}

--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -4,7 +4,7 @@ type VHDXMetadata struct {
 	BlockSize          uint64
 	HasParent          bool
 	VirtualDiskSize    uint64
-	LogicalSectorSize  uint32
+	LogicalSectorSize  uint64
 	PhysicalSectorSize uint32
 	VirtualDiskId      string
 }
@@ -30,8 +30,8 @@ func (self *Metadata) ParseMetadata() *VHDXMetadata {
 				self.Offset+int64(e.MetadataOffset()))
 
 		case MetadataLogicalSectorSize:
-			result.LogicalSectorSize = ParseUint32(self.Reader,
-				self.Offset+int64(e.MetadataOffset()))
+			result.LogicalSectorSize = uint64(ParseUint32(self.Reader,
+				self.Offset+int64(e.MetadataOffset())))
 
 		case MetadataPhysicalSectorSize:
 			result.PhysicalSectorSize = ParseUint32(self.Reader,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -76,8 +76,19 @@ func NewVHDXFile(reader io.ReaderAt) (*VHDXFile, error) {
 			self.Metadata.VirtualDiskSize)
 	}
 
+	if self.Metadata.LogicalSectorSize <= 0 {
+		return nil, fmt.Errorf("LogicalSectorSize invalid: %v",
+			self.Metadata.LogicalSectorSize)
+	}
+
 	self.bat_reader.BlockSize = self.Metadata.BlockSize
 	self.bat_reader.Size = self.Metadata.VirtualDiskSize
+	self.bat_reader.EntriesPerChunk = (1 << 23) * self.Metadata.LogicalSectorSize / self.Metadata.BlockSize
+
+	if self.bat_reader.EntriesPerChunk == 0 {
+		return nil, fmt.Errorf("EntriesPerChunk invalid: %v",
+			self.bat_reader.EntriesPerChunk)
+	}
 
 	// Now parse the BAT and build the reader.
 	for i, b := range self.bat {


### PR DESCRIPTION
The Block Allocation Table is actually divided into chunks, and each chunk contains a single sector block. Therefore each chunks contains one less block than can fit in it so we need to correct for that by adding a block per chunk.

This resulted in an off by one bug for each block past the chunk size.